### PR TITLE
add recursive parameter to the git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For Windows users, you can build and run the system on WSL(Windows Subsystem for
 
 #### Building
 ```
-git clone https://github.com/AymenSekhri/CyanOS.git
+git clone --recursive https://github.com/AymenSekhri/CyanOS.git
 cd ./CyanOS
 mkdir build && cd build
 cmake ..


### PR DESCRIPTION
the project makes use of the googletest submodule, you must add the --recursive parameter to the git clone command for the submodule to be cloned too, else cmake will throw an error about not finding it.