### PR TITLE
fix compile error caused by case sensitivity

### DIFF
--- a/kernel/Devices/DebugPort/DebugPort.cpp
+++ b/kernel/Devices/DebugPort/DebugPort.cpp
@@ -1,6 +1,6 @@
 #include "DebugPort.h"
 #include "Arch/x86/asm.h"
-#include "lib/stdlib.h"
+#include "Lib/stdlib.h"
 
 void DebugPort::write(const char* data, size_t size, DebugColor color)
 {


### PR DESCRIPTION
Linux based systems have a case-sensitive filesystem, so "lib/stdlib.h" and ""Lib/stdlib.h" are totally different files.